### PR TITLE
Support pandas 2/3, modern websockets, and Python 3.12+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pyflapjack"
 version = "1.1.0"
 description = "Python package that interfaces the Flapjack API"
 readme = "README.md"
-requires-python = ">=3.7,<3.11"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 keywords = ["flapjack", "data", "experimental", "analysis", "synthetic biology"]
 authors = [
@@ -24,18 +24,17 @@ classifiers = [
 ]
 
 dependencies = [
-  'numpy== 1.26.2',
-  'scipy==1.11.0',
-  'pandas==1.5.3',
+  'numpy>=1.26',
+  'scipy>=1.11',
+  'pandas>=2.0',
   'requests>=2.25.1',
-  'tqdm==4.62.3',
-  'plotly==5.3.1',
-  'asyncio==3.4.3',
-  'nest_asyncio==1.5.1',
-  'requests_jwt==0.5.3',
-  'websockets==10.0',
+  'tqdm>=4.62',
+  'plotly>=5.3',
+  'nest_asyncio>=1.5',
+  'requests_jwt>=0.5.3',
+  'websockets>=12',
   'matplotlib>=3.10',
-  'kaleido==0.2.1'
+  'kaleido>=0.2.1'
 ]
 
 [project.optional-dependencies]

--- a/src/flapjack/flapjack.py
+++ b/src/flapjack/flapjack.py
@@ -1,3 +1,4 @@
+import io
 import requests
 from requests.exceptions import HTTPError
 from requests_jwt import JWTAuth
@@ -307,7 +308,7 @@ class Flapjack():
             "parameters": params,
             "data": data
         }
-        async with websockets.connect(uri, max_size=1e10) as websocket:
+        async with websockets.connect(uri, max_size=int(1e10)) as websocket:
             await websocket.send(json.dumps(payload))
             response_json = await websocket.recv()
             response_data = json.loads(response_json)
@@ -338,7 +339,7 @@ class Flapjack():
             "type":"measurements",
             "parameters": params
         }
-        async with websockets.connect(uri, max_size=1e10) as websocket:
+        async with websockets.connect(uri, max_size=int(1e10)) as websocket:
             await websocket.send(json.dumps(payload))
             response_json = await websocket.recv()
             response_data = json.loads(response_json)
@@ -348,7 +349,7 @@ class Flapjack():
             if response_data['type']=='measurements':
                 df_json = response_data['data']
                 if df_json:
-                    return pd.read_json(df_json)
+                    return pd.read_json(io.StringIO(df_json))
                 else:
                     return
             else:
@@ -387,7 +388,7 @@ class Flapjack():
                 while response_data['type']=='progress_update':
                 #while progress < 100:
                     progress = response_data['progress']
-                    rows.append(pd.read_json(response_data['data']))
+                    rows.append(pd.read_json(io.StringIO(response_data['data'])))
                     response_json = await websocket.recv()
                     response_data = json.loads(response_json)
                     pbar.update(progress-progress_prev)
@@ -396,7 +397,7 @@ class Flapjack():
                 pbar.close()
             result = pd.DataFrame()
             if len(rows):
-                result = result.append(rows)
+                result = pd.concat(rows, ignore_index=True)
             print('Returning dataframe')
             return result
             '''
@@ -428,7 +429,7 @@ class Flapjack():
             "type":"plot",
             "parameters": params
         }
-        async with websockets.connect(uri, max_size=1e10) as websocket:
+        async with websockets.connect(uri, max_size=int(1e10)) as websocket:
             await websocket.send(json.dumps(payload))
             response_json = await websocket.recv()
             response_data = json.loads(response_json)


### PR DESCRIPTION
Relax the dependency pins that blocked running alongside a pandas-2 stack (pandas>=2.0, numpy>=1.26, scipy>=1.11, websockets>=12), and widen requires-python to >=3.9. Drop the redundant asyncio backport pin, which does not install on modern Python.

Both PRs for this repo (#25 and #27) won't be necessary if we only pin major and minor versions ([see here for more info on semantic versioning](https://semver.org/)).